### PR TITLE
Remove containers on dismiss + refactoring init

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
       "!**/node_modules/**",
       "!**/dist/**"
     ],
-    "preset": "rollup-jest",
     "testEnvironment": "jest-environment-jsdom-fourteen"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,89 +6,53 @@ const defaults = {
   opacity: 1
 };
 
-let initialized = false;
+const COMMON_STYLES =
+  "width:100%;z-index:99999;position:fixed;pointer-events:none;display:flex;flex-direction:column;padding:15px;";
+
+const CONTAINER_STYLES = {
+  "top-left": "left:0;top:0;text-align:left;align-items:flex-start;",
+  "top-right": "right:0;top:0;text-align:right;align-items:flex-end;",
+  "top-center": "top:0;left:0;right:0;text-align:center;align-items:center;",
+  "bottom-left": "left:0;bottom:0;text-align:left;align-items:flex-start;",
+  "bottom-right": "right:0;bottom:0;text-align:right;align-items:flex-end;",
+  "bottom-center": "bottom:0;left:0;right:0;text-align:center;align-items:center;",
+  "center": "top:0;left:0;right:0;bottom:0;flex-flow:column;justify-content:center;align-items:center;"
+};
+
 let containers = {};
-let positions = {};
 let doc = document;
 
-function init() {
-  containers = {
-    noticesTopLeft: doc.createElement("div"),
-    noticesTopRight: doc.createElement("div"),
-    noticesBottomLeft: doc.createElement("div"),
-    noticesBottomRight: doc.createElement("div"),
-    noticesTopCenter: doc.createElement("div"),
-    noticesBottomCenter: doc.createElement("div"),
-    noticesCenter: doc.createElement("div")
-  };
+function findOrCreateContainer(position) {
+  if (containers.position) return containers.position;
 
-  let style =
-    "width:100%;z-index:99999;position:fixed;pointer-events:none;display:flex;flex-direction:column;padding:15px;";
+  const container = doc.createElement("div");
 
-  containers.noticesTopLeft.setAttribute(
-    "style",
-    `${style}left:0;top:0;text-align:left;align-items:flex-start;`
-  );
-  containers.noticesTopRight.setAttribute(
-    "style",
-    `${style}right:0;top:0;text-align:right;align-items:flex-end;`
-  );
-  containers.noticesBottomLeft.setAttribute(
-    "style",
-    `${style}left:0;bottom:0;text-align:left;align-items:flex-start;`
-  );
-  containers.noticesBottomRight.setAttribute(
-    "style",
-    `${style}right:0;bottom:0;text-align:right;align-items:flex-end;`
-  );
-  containers.noticesTopCenter.setAttribute(
-    "style",
-    `${style}top:0;left:0;right:0;text-align:center;align-items:center;`
-  );
-  containers.noticesBottomCenter.setAttribute(
-    "style",
-    `${style}bottom:0;left:0;right:0;text-align:center;align-items:center;`
-  );
-  containers.noticesCenter.setAttribute(
-    "style",
-    `${style}top:0;left:0;right:0;bottom:0;flex-flow:column;justify-content:center;align-items:center;`
-  );
+  container.setAttribute("style", COMMON_STYLES + CONTAINER_STYLES[position]);
 
-  for (let key in containers) {
-    doc.body.appendChild(containers[key]);
-  }
+  doc.body.appendChild(container);
 
-  positions = {
-    "top-left": containers.noticesTopLeft,
-    "top-right": containers.noticesTopRight,
-    "top-center": containers.noticesTopCenter,
-    "bottom-left": containers.noticesBottomLeft,
-    "bottom-right": containers.noticesBottomRight,
-    "bottom-center": containers.noticesBottomCenter,
-    center: containers.noticesCenter
-  };
+  containers.position = container;
 
-  initialized = true;
+  return container;
 }
 
 export function toast(params) {
-  if (!initialized) init();
   let options = Object.assign({}, defaults, params);
 
   const toast = new Toast(options);
-  const container = positions[options.position] || positions[defaults.position];
+  const container = findOrCreateContainer(options.position || defaults.position);
 
   container.appendChild(toast.element);
 }
 
 export function setDoc(newDoc) {
   for (let key in containers) {
-    let element = containers[key];
-    element.parentNode.removeChild(element);
+    containers[key].remove();
   }
 
+  containers = {};
+
   doc = newDoc;
-  init();
 }
 
 class Toast {
@@ -154,14 +118,14 @@ class Toast {
   destroy() {
     if (this.animate && this.animate.out) {
       this.element.classList.add(this.animate.out);
-      this.onAnimationEnd(() => this.removeChild(this.element));
+      this.onAnimationEnd(() => this.removeParent(this.element));
     } else {
-      this.removeChild(this.element);
+      this.removeParent(this.element);
     }
   }
 
-  removeChild(element) {
-    if (element.parentNode) element.parentNode.removeChild(element);
+  removeParent(element) {
+    if (element.parentNode) element.parentNode.remove();
   }
 
   onAnimationEnd(callback = () => {}) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,9 +11,10 @@ describe("toast", () => {
         dismissible: true,
         duration: 1000,
         pauseOnHover: true,
-        animate: { in: "fadeIn", out: "fadeOut" }
       })
     );
+
+    setDoc(document) // cleaning up
   });
 
   it("should not contain a notification", () => {
@@ -27,5 +28,15 @@ describe("toast", () => {
     const notification = document.querySelector(".notification");
     expect(notification.textContent).toBe("Hello there");
     expect(notification.classList.contains("is-primary")).toBeTruthy();
+  });
+
+  it("should remove notification with container on close", () => {
+    const button = document.querySelector(".toast");
+    button.click();
+    const notification = document.querySelector(".notification");
+    expect(notification.textContent).toBe("Hello there");
+    expect(notification.classList.contains("is-primary")).toBeTruthy();
+    notification.querySelector('.delete').click();
+    expect(document.body.querySelector('div')).toBeFalsy()
   });
 });


### PR DESCRIPTION
When I started to use this lib I saw that it generates redundant nodes in dom on init. And it doesn't remove these nodes on toast dismiss.

Most of the time we need to show only one notification (in one position) - it makes sense to create container nodes when it's required.

When toast is dismissed it makes sense to remove containers as well

I've removed init func and swapped with `findOrCreateContainer` to avoid redundant containers on start.
I changed removal func to remove containers.

redundant containers:
![image](https://user-images.githubusercontent.com/9060346/78728023-eed39b80-793e-11ea-8a3d-a9e5eeea6e31.png)