### PR TITLE
Add more color supported from bulma

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,11 @@ export type ToastType = 'is-primary'
   | 'is-info'
   | 'is-success'
   | 'is-warning'
-  | 'is-danger';
+  | 'is-danger'
+  | 'is-white'
+  | 'is-black'
+  | 'is-light'
+  | 'is-dark';
 
 export type ToastPosition = 'top-left'
   | 'top-right'


### PR DESCRIPTION
This PR add more supported color mentioned in bulma main website.

`is-black` `is-white` `is-light` and `is-dark`