### PR TITLE
Support animate.css v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Bulma Toast supports [animate.css](https://daneden.github.io/animate.css/) (and 
   <head>
     <link rel="stylesheet" href="animate.min.css">
     <!-- or -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/animate.css@3.5.2/animate.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/animate.css@4.0.0/animate.min.css">
     <!-- or -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.0.0/animate.min.css">
   </head>
 ```
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Bulma Toast</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.0.0/animate.min.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.8.6/showdown.min.js"></script>
   <script src="dist/bulma-toast.min.js"></script>
 

--- a/src/index.js
+++ b/src/index.js
@@ -81,9 +81,10 @@ class Toast {
     const classes = ['notification']
     if (this.type) classes.push(this.type)
     if (this.animate && this.animate.in) {
-      const speed = this.animate.speed || 'faster'
-      classes.push(`animated ${this.animate.in} ${speed}`)
-      this.onAnimationEnd(() => this.element.classList.remove(this.animate.in))
+      const animateInClass = `animate__${this.animate.in}`
+      const speed = this.animate.speed ? `animate__${this.animate.speed}` : 'animate__faster'
+      classes.push(`animate__animated ${animateInClass} ${speed}`)
+      this.onAnimationEnd(() => this.element.classList.remove(animateInClass))
     }
 
     this.element.className = classes.join(' ')
@@ -126,7 +127,7 @@ class Toast {
 
   destroy() {
     if (this.animate && this.animate.out) {
-      this.element.classList.add(this.animate.out)
+      this.element.classList.add(`animate__${this.animate.out}`)
       this.onAnimationEnd(() => {
         this.removeParent(this.element)
         delete containers.position

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -41,3 +41,38 @@ describe('toast', () => {
     expect(document.body.querySelector('div')).toBeFalsy()
   })
 })
+
+describe('animations', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <head>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.0.0/animate.min.css">
+      </head>
+      <body>
+        <button class='toast'>Toast</button>
+      </body>
+    `
+    document.querySelector('.toast').addEventListener('click', () =>
+      toast({
+        message: 'Hello there',
+        type: 'is-primary',
+        position: 'top-left',
+        dismissible: true,
+        duration: 1000,
+        single: true,
+        animate: { in: 'fadeIn', out: 'fadeOut' }
+      }),
+    )
+
+    setDoc(document) // cleaning up
+  })
+
+  it('should show notification with animation', () => {
+    document.querySelector('.toast').click()
+    const notification = document.querySelector('.notification')
+    expect(notification.classList.contains('animate__animated')).toBeTruthy()
+    expect(notification.classList.contains('animate__fadeIn')).toBeTruthy()
+    notification.querySelector('.delete').click()
+    expect(notification.classList.contains('animate__fadeOut')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
This PR allows to use bulma-toast with animate.css v4. But it breaks animate.css v3 support.

https://animate.style/#migration

I'm not sure if this kind of breaking changes is ok for you