### PR TITLE
Add extraClasses option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ export interface Options {
   opacity?: number;
   animate?: ToastAnimation;
   appendTo?: Node;
+  extraClasses?: string;
 }
 
 export type ToastType = 'is-primary'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "bulma-toast",
-  "version": "2.3.1",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.3.0",
+      "version": "2.4.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulma-toast",
-  "version": "2.3.1",
+  "version": "2.4.1",
   "description": "Bulma's pure JavaScript extension to display toasts",
   "main": "dist/bulma-toast.cjs.js",
   "module": "dist/bulma-toast.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const baseConfig = {
   offsetBottom: 0,
   offsetLeft: 0,
   offsetRight: 0,
+  extraClasses: '',
 }
 let defaults = { ...baseConfig }
 let containers = {}
@@ -128,9 +129,10 @@ class Toast {
     this.offsetBottom = options.offsetBottom
     this.offsetLeft = options.offsetLeft
     this.offsetRight = options.offsetRight
+    this.extraClasses = options.extraClasses
 
     let style = `width:auto;pointer-events:auto;display:inline-flex;white-space:pre-wrap;opacity:${this.opacity};`
-    const classes = ['notification']
+    const classes = ['notification', extraClasses]
     if (this.type) classes.push(this.type)
     if (this.animate && this.animate.in) {
       const animateInClass = `animate__${this.animate.in}`

--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ class Toast {
     this.extraClasses = options.extraClasses
 
     let style = `width:auto;pointer-events:auto;display:inline-flex;white-space:pre-wrap;opacity:${this.opacity};`
-    const classes = ['notification', extraClasses]
+    const classes = ['notification', this.extraClasses]
     if (this.type) classes.push(this.type)
     if (this.animate && this.animate.in) {
       const animateInClass = `animate__${this.animate.in}`


### PR DESCRIPTION
Just adding an `extraClasses` string option to allow people to add any styling they need to on the notification element created by `bulma-toast`.

For example, I used `extraClasses` to pass in `is-light py-3 px-4` to make the notifications look how I want them too. There wasn’t a particularly elegant non-Javascript way to accomplish this otherwise while reusing Bulma classes. 

Addresses #203.