### PR TITLE
Allow 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ export interface Options {
   opacity?: number;
   animate?: ToastAnimation;
   appendTo?: Node;
+  extraClasses?: string;
 }
 
 export type ToastType = 'is-primary'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "bulma-toast",
-  "version": "2.3.1",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.3.0",
+      "version": "2.4.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.6.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "browser": "dist/bulma-toast.min.js",
   "scripts": {
     "build": "rollup -c",
-    "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "start": "rollup -c -w",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulma-toast",
-  "version": "2.3.1",
+  "version": "2.4.1",
   "description": "Bulma's pure JavaScript extension to display toasts",
   "main": "dist/bulma-toast.cjs.js",
   "module": "dist/bulma-toast.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const baseConfig = {
   offsetBottom: 0,
   offsetLeft: 0,
   offsetRight: 0,
+  extraClasses: '',
 }
 let defaults = { ...baseConfig }
 let containers = {}
@@ -128,9 +129,10 @@ class Toast {
     this.offsetBottom = options.offsetBottom
     this.offsetLeft = options.offsetLeft
     this.offsetRight = options.offsetRight
+    this.extraClasses = options.extraClasses
 
     let style = `width:auto;pointer-events:auto;display:inline-flex;white-space:pre-wrap;opacity:${this.opacity};`
-    const classes = ['notification']
+    const classes = ['notification', extraClasses]
     if (this.type) classes.push(this.type)
     if (this.animate && this.animate.in) {
       const animateInClass = `animate__${this.animate.in}`

--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ class Toast {
     this.extraClasses = options.extraClasses
 
     let style = `width:auto;pointer-events:auto;display:inline-flex;white-space:pre-wrap;opacity:${this.opacity};`
-    const classes = ['notification', extraClasses]
+    const classes = ['notification', this.extraClasses]
     if (this.type) classes.push(this.type)
     if (this.animate && this.animate.in) {
       const animateInClass = `animate__${this.animate.in}`


### PR DESCRIPTION
This PR changes the `prepublishOnly` script in `package.json` to `prepare`.

Right now, if one tries to add a Github fork of the project as a dependency, the project cannot properly be used, because `dist/` is not committed to the repo; it is ignored by Git.

This means `npm run build` will be run not only before publishing the package to npm, but also when installing the package to `node_modules/`. In other words, `dist/` will now automatically be built when if this project is added as a dependency if it wasn’t already built.

The alternatives would be to

1. commit `dist/` to the repo, but this is inelegant.
2. create a Github release that includes building as part the workflow and install using a link to the generated tarball, but this is time-consuming for both the repo maintainer and user, and does not allow for seamless upgrading.

In comparison, the approach of this PR is harmless to most, and incredibly helpful to people forking this repository.