### PR TITLE
message not optional in type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export function setDefaults(options: Options): void;
 export function resetDefaults(): void;
 
 export interface Options {
-  message?: string | HTMLElement;
+  message: string | HTMLElement;
   type?: ToastType;
   duration?: number;
   position?: ToastPosition;


### PR DESCRIPTION
Update types to ensure a message is given to avoid failing the runtime message validation:
`if (!params.message) throw new Error('message is required')`